### PR TITLE
Add meta ad creative generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,25 @@ python task_manager.py delete 1
 ```
 
 Tasks are stored in `tasks.json` in the current directory.
+
+---
+
+## Meta Ad Creative Generator
+
+This script generates simple Meta ad creatives from a CSV file containing business details.
+
+### Usage
+
+Prepare a CSV file with the following headers:
+
+```
+business,product,description,audience,offer,cta
+```
+
+Run the generator:
+
+```bash
+python meta_ad_generator.py input.csv output.csv
+```
+
+The output CSV will contain all original columns plus a `creative` column with the generated ad text.

--- a/meta_ad_generator.py
+++ b/meta_ad_generator.py
@@ -1,0 +1,66 @@
+import argparse
+import csv
+import random
+from pathlib import Path
+from typing import List, Dict
+
+TEMPLATES = [
+    "{Business} presents {Product}! {Description} Perfect for {Audience}. {Offer} {CTA}",
+    "Discover {Product} from {Business}: {Description} Ideal for {Audience}. {Offer} {CTA}",
+    "Need {Product}? {Business} has you covered. {Description} {Offer} {CTA}",
+    "🚀 {Product} by {Business}! {Description} Great for {Audience}. {Offer} {CTA}",
+]
+
+
+def load_rows(path: Path) -> List[Dict[str, str]]:
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    return rows
+
+
+def generate_creative(data: Dict[str, str]) -> str:
+    template = random.choice(TEMPLATES)
+    return template.format(
+        Business=data.get('business', '').strip(),
+        Product=data.get('product', '').strip(),
+        Description=data.get('description', '').strip(),
+        Audience=data.get('audience', '').strip(),
+        Offer=data.get('offer', '').strip(),
+        CTA=data.get('cta', '').strip(),
+    )
+
+
+def generate_creatives(rows: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    for row in rows:
+        row['creative'] = generate_creative(row)
+    return rows
+
+
+def write_rows(rows: List[Dict[str, str]], path: Path):
+    if not rows:
+        return
+    fieldnames = list(rows[0].keys())
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Generate meta ad creatives from CSV data')
+    parser.add_argument('input', help='Path to input CSV file')
+    parser.add_argument('output', help='Path to output CSV file')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    rows = load_rows(Path(args.input))
+    rows = generate_creatives(rows)
+    write_rows(rows, Path(args.output))
+    print(f"Generated {len(rows)} ad creatives in {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_meta_ad_generator.py
+++ b/tests/test_meta_ad_generator.py
@@ -1,0 +1,22 @@
+import csv
+from io import StringIO
+import unittest
+
+from meta_ad_generator import generate_creatives
+
+
+class TestMetaAdGenerator(unittest.TestCase):
+    def test_generate_creatives_adds_column(self):
+        csv_data = (
+            "business,product,description,audience,offer,cta\n"
+            "Acme,Widget,Bright and shiny,DIYers,20% off,Buy now\n"
+        )
+        reader = csv.DictReader(StringIO(csv_data))
+        rows = list(reader)
+        result = generate_creatives(rows)
+        self.assertIn('creative', result[0])
+        self.assertTrue(result[0]['creative'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `meta_ad_generator.py` to create simple ad creatives from CSV input
- document new ad creative generator usage in `README.md`
- add `tests/test_meta_ad_generator.py` for basic unit test

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_684b73384eac832c937f506ff0fdacc6